### PR TITLE
Remove init file from namespaced package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
     long_description=Path("README.rst").read_text(),
     url="https://github.com/thoth-station/source-management",
     license="GPLv3+",
-    packages=setuptools.find_packages(),
+    packages=["thoth.sourcemanagement"],
     install_requires=get_install_requires(),
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/thoth/__init__.py
+++ b/thoth/__init__.py
@@ -1,1 +1,0 @@
-"""Though SourceManagement."""


### PR DESCRIPTION
## Related Issues and Dependencies

Namespaced packages *must not* include `__init__.py` in the namespace. This is causing import issues when used in components, such as investigator.

Related: https://github.com/thoth-station/investigator/pull/361

## This introduces a breaking change

- [x] No
