### PR TITLE
jwt encoding is a string, decoding defeats purpose

### DIFF
--- a/thoth/sourcemanagement/github_authentication.py
+++ b/thoth/sourcemanagement/github_authentication.py
@@ -66,7 +66,7 @@ class GithubAuthentication:
         jwt_generated = jwt.encode(payload, private_key, algorithm="RS256")
 
         headers = {
-            "Authorization": "Bearer {}".format(jwt_generated.decode()),
+            "Authorization": "Bearer {}".format(jwt_generated),
             "Accept": "application/vnd.github.machine-man-preview+json",
         }
         return headers


### PR DESCRIPTION
## Related Issues and Dependencies

this causes a runtime error because encoded is just a string.  The correct call would be `jwt.decode(jwt_generated)` but according to GitHub authentication documentation I believe that the string should not be decoded. [0]

## Links
[0] https://docs.github.com/en/developers/apps/authenticating-with-github-apps (Ctrl-F jwt)